### PR TITLE
Fixed second frame buffer overlapping with the first.

### DIFF
--- a/sw/src/main.c
+++ b/sw/src/main.c
@@ -71,7 +71,7 @@ void core1_main() {
 
 //Use two framebuffers to prevent tearing
 uint16_t * framebuffer = (uint16_t *)(0x20000000 + (1024 * 30));
-uint16_t * framebuffer2 = (uint16_t *)(0x20000000 + (1024 * 30) + (pixels_in_scanline * scanlines_in_active_area));
+uint16_t * framebuffer2 = (uint16_t *)(0x20000000 + (1024 * 30) + (pixels_in_scanline * scanlines_in_active_area * 2));
 
 uint32_t pot_history[16];
 uint32_t brightness = 0;


### PR DESCRIPTION
Each pixel is 2 bytes so the offset for the 2nd frame buffer needs to be double the pixel count, otherwise the 2nd frame overwrites the bottom half of the first.